### PR TITLE
F64 support

### DIFF
--- a/src/tool/core/helpers/problem_code.rs
+++ b/src/tool/core/helpers/problem_code.rs
@@ -227,8 +227,10 @@ impl FunctionArgs {
 pub enum FunctionArgType {
     I32,
     I64,
+    F64,
     Bool,
     VecI32,
+    VecF64,
     VecBool,
     VecVecI32,
     String_,
@@ -254,7 +256,13 @@ impl FunctionArgType {
                 };
                 line.to_string()
             }
-            VecI32 | VecBool => {
+            F64 => {
+                if let Err(e) = line.parse::<f64>() {
+                    warn!("In testing the test input \"{line}\" the parsing to f64 failed with error: {e}")
+                };
+                line.to_string()
+            }
+            VecI32 | VecBool | VecF64 => {
                 Self::does_pass_basic_vec_tests(line)?;
                 format!("vec!{line}")
             }
@@ -304,8 +312,10 @@ impl Display for FunctionArgType {
         let s = match self {
             I32 => "i32",
             I64 => "i64",
+            F64 => "f64",
             Bool => "bool",
             VecI32 => "Vec<i32>",
+            VecF64 => "Vec<f64>",
             VecBool => "Vec<bool>",
             VecVecI32 => "Vec<Vec<i32>>",
             String_ => "String",
@@ -326,8 +336,10 @@ impl TryFrom<&str> for FunctionArgType {
         Ok(match value.trim() {
             "i32" => I32,
             "i64" => I64,
+            "f64" => F64,
             "bool" => Bool,
             "Vec<i32>" => VecI32,
+            "Vec<f64>" => VecF64,
             "Vec<bool>" => VecBool,
             "Vec<Vec<i32>>" => VecVecI32,
             "String" => String_,

--- a/src/tool/core/helpers/problem_code.rs
+++ b/src/tool/core/helpers/problem_code.rs
@@ -249,7 +249,7 @@ impl FunctionArgType {
                 line.to_string()
             }
             I64 => {
-                if let Err(e) = line.parse::<i32>() {
+                if let Err(e) = line.parse::<i64>() {
                     warn!("In testing the test input \"{line}\" the parsing to i64 failed with error: {e}")
                 };
                 line.to_string()

--- a/src/tool/core/helpers/problem_code.rs
+++ b/src/tool/core/helpers/problem_code.rs
@@ -136,6 +136,15 @@ impl FunctionInfo {
         names.join(", ")
     }
 
+    pub fn get_solution_comparison_code(&self) -> String {
+        if let Some(FunctionArgType::F64) = &self.return_type {
+            "assert!((actual - expected).abs() < 1e-5, \"Assertion failed: actual {actual:.5} but expected {expected:.5}. Diff is more than 1e-5.\");"
+        } else {
+            "assert_eq!(actual, expected);"
+        }
+        .to_string()
+    }
+
     pub fn get_test_case(&self, example_test_case_raw: &str) -> anyhow::Result<String> {
         let mut result = String::new();
         let n = self.fn_args.len();

--- a/src/tool/core/helpers/problem_metadata.rs
+++ b/src/tool/core/helpers/problem_metadata.rs
@@ -97,11 +97,12 @@ mod tests {{
         let test_fn = format!(
             "    fn case({}) {{
         let actual = Solution::{}({});
-        assert_eq!(actual, expected);
-    }}", // TODO add support for same value within 5 decimal places
+        {}
+    }}",
             fn_info.get_args_with_case(),
             fn_info.name,
-            fn_info.get_args_names()
+            fn_info.get_args_names(),
+            fn_info.get_solution_comparison_code(),
         );
         result.push_str(&test_fn);
 

--- a/src/tool/core/helpers/problem_metadata.rs
+++ b/src/tool/core/helpers/problem_metadata.rs
@@ -98,7 +98,7 @@ mod tests {{
             "    fn case({}) {{
         let actual = Solution::{}({});
         assert_eq!(actual, expected);
-    }}",
+    }}", // TODO add support for same value within 5 decimal places
             fn_info.get_args_with_case(),
             fn_info.name,
             fn_info.get_args_names()


### PR DESCRIPTION
- Fix typo in i64
- Add f64 and Vec<f64> as known types
- Add approximately equal checking to 5 decimal places on problems where return type is f64