### PR TITLE
Make leetcode env feature default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-i = "install --path ."
+i = "install --path . --features=tool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,13 @@ serde = { version = "1.0.164", features = ["derive"], optional = true }
 ureq = { version = "2.6", features = ["json"], optional = true }
 
 
+[[bin]]
+name = "cargo-leet"
+path = "src/main.rs"
+required-features = ["tool"]
+
 [features]
-default = ["tool"]
+default = ["leet_env"]
 # Add support for leetcode's environment
 leet_env = []
 # Items used when running as a binary

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@
  Using the library to "mimic" leetcode environment. Add library as a dependency as below. Then add use statements as necessary (automatically added if tool is used to generate the file).
 
  ```toml
- cargo-leet = { git = "https://github.com/rust-practice/cargo-leet.git", branch = "develop", default-features = false, features = [
-    "leet_env",
-] }
+ cargo-leet = { git = "https://github.com/rust-practice/cargo-leet.git", branch = "develop" }
  ```
 
 
@@ -29,7 +27,7 @@ NB: If cargo-leet is already installed you do the install it will just replace i
 ### From GitHub
 
 ```sh
-cargo install --git https://github.com/rust-practice/cargo-leet.git --branch main
+cargo install --git https://github.com/rust-practice/cargo-leet.git --branch main --features=tool
 ```
 
 ### From Clone
@@ -37,7 +35,7 @@ cargo install --git https://github.com/rust-practice/cargo-leet.git --branch mai
 After cloning the repo run
 
 ```sh
-cargo install --path .
+cargo install --path . --features=tool
 ```
 
 or using alias from `.cargo/config.toml`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,15 @@
 #![forbid(unsafe_code)]
 
-#[cfg(feature = "leet_env")]
-mod leetcode_env;
-#[cfg(feature = "tool")]
-mod tool;
-
 // For use in external code
 #[cfg(feature = "leet_env")]
-pub use leetcode_env::list::ListHead;
+mod leetcode_env;
 #[cfg(feature = "leet_env")]
-pub use leetcode_env::list::ListNode;
-#[cfg(feature = "leet_env")]
-pub use leetcode_env::tree::TreeNode;
-#[cfg(feature = "leet_env")]
-pub use leetcode_env::tree::TreeRoot;
+pub use leetcode_env::{
+    list::{ListHead, ListNode},
+    tree::{TreeNode, TreeRoot},
+};
 
-// For use in main.rs
 #[cfg(feature = "tool")]
-pub use crate::tool::cli::CargoCli;
+mod tool;
 #[cfg(feature = "tool")]
-pub use crate::tool::core::run;
-#[cfg(feature = "tool")]
-pub use crate::tool::log::init_logging;
+pub use crate::tool::{cli::CargoCli, core::run, log::init_logging};


### PR DESCRIPTION
- update cargo toml
  - use leet_env as default feature
  - make tool required feature for bin
- update readme install and library instructions
   - no features required from lib
   - feature `tool` required for bin
- update cargo alias to use default feature
