### PR TITLE
Save problem number preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cargo leet [OPTIONS] <COMMAND>
   ```
 
 - **generate, -g, gen**
-  Generates a module for the specified problem, allowing you to start working on the solution locally. You can provide a LeetCode problem slug or URL, or leave it blank to use the daily challenge. Pass `-n` or `--number_in_name` to include the problem number in the file name.
+  Generates a module for the specified problem, allowing you to start working on the solution locally. You can provide a LeetCode problem slug or URL, or leave it blank to use the daily challenge. See [Examples](#examples) for passing different options.
 
   ```sh
   cargo leet generate [OPTIONS] [PROBLEM]
@@ -75,13 +75,17 @@ cargo leet [OPTIONS] <COMMAND>
 
 - **Generate a module for a specific problem**:
 
-  Without the problem number:
+  Include problem numbers in the file name depending on the config:
   ```sh
   cargo leet generate two-sum
   ```
-  With the problem number:
+  Forcibly add the problem number (overriding the config):
   ```sh
   cargo leet generate -n two-sum
+  ```
+  Forcibly exclude the problem number (overriding the config):
+  ```sh
+  cargo leet generate -m two-sum
   ```
 
 - **Set the active problem (done automatically by `cargo leet gen`)**:

--- a/bacon.toml
+++ b/bacon.toml
@@ -73,6 +73,34 @@ need_stdout = true
 allow_warnings = true
 background = true
 
+[jobs.run-help-generate-short]
+command = [
+    "cargo",
+    "run",
+    "--features=tool",
+    "--",
+    "leet",
+    "generate",
+    "-h",
+]
+need_stdout = true
+allow_warnings = true
+background = true
+
+[jobs.run-help-generate-long]
+command = [
+    "cargo",
+    "run",
+    "--features=tool",
+    "--",
+    "leet",
+    "generate",
+    "--help",
+]
+need_stdout = true
+allow_warnings = true
+background = true
+
 # This parameterized job runs the example of your choice, as soon
 # as the code compiles.
 # Call it as
@@ -89,3 +117,5 @@ background = true
 [keybindings]
 alt-h = "job:run-help-short"
 ctrl-h = "job:run-help-long"
+g = "job:run-help-generate-long"
+alt-g = "job:run-help-generate-short"

--- a/bacon.toml
+++ b/bacon.toml
@@ -47,24 +47,31 @@ command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
 need_stdout = false
 on_success = "back" # so that we don't open the browser at each change
 
-# You can run your application and have the result displayed in bacon,
-# *if* it makes sense for this crate.
-# Don't forget the `--color always` part or the errors won't be
-# properly parsed.
-# If your program never stops (eg a server), you may set `background`
-# to false to have the cargo run output immediately displayed instead
-# of waiting for program's end.
-# [jobs.run]
-# command = [
-#   "cargo",
-#   "run",
-#   "--color",
-#   "always",
-#   # put launch parameters for your program behind a `--` separator
-# ]
-# need_stdout = true
-# allow_warnings = true
-# background = true
+[jobs.run-help-short]
+command = [
+    "cargo",
+    "run",
+    "--features=tool",
+    "--",
+    "leet",
+    "-h",
+]
+need_stdout = true
+allow_warnings = true
+background = true
+
+[jobs.run-help-long]
+command = [
+    "cargo",
+    "run",
+    "--features=tool",
+    "--",
+    "leet",
+    "--help",
+]
+need_stdout = true
+allow_warnings = true
+background = true
 
 # This parameterized job runs the example of your choice, as soon
 # as the code compiles.
@@ -80,4 +87,5 @@ on_success = "back" # so that we don't open the browser at each change
 # Shortcuts to internal functions (scrolling, toggling, etc.)
 # should go in your personal global prefs.toml file instead.
 [keybindings]
-# alt-m = "job:my-job"
+alt-h = "job:run-help-short"
+ctrl-h = "job:run-help-long"

--- a/src/tool/cli.rs
+++ b/src/tool/cli.rs
@@ -75,9 +75,24 @@ pub enum Commands {
 pub struct GenerateArgs {
     /// Question slug or url (If none specified then daily challenge is used)
     pub problem: Option<String>,
+
     /// If set the module name generated includes the number for the problem
-    #[arg(short = 'n', long = "number_in_name", default_value_t = false)]
+    #[arg(
+        group = "mod_name",
+        short = 'n',
+        long = "number_in_name",
+        default_value_t = false
+    )]
     pub should_include_problem_number_in_mod_name: bool,
+
+    /// If set the module name generated will not include the number for the problem
+    #[arg(
+        group = "mod_name",
+        short = 'm',
+        long = "number_not_in_name",
+        default_value_t = false
+    )]
+    pub should_not_include_problem_number_in_mod_name: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/tool/cli.rs
+++ b/src/tool/cli.rs
@@ -77,7 +77,7 @@ pub struct GenerateArgs {
     pub problem: Option<String>,
     /// If set the module name generated includes the number for the problem
     #[arg(short = 'n', long = "number_in_name", default_value_t = false)]
-    pub should_include_problem_number: bool,
+    pub should_include_problem_number_in_mod_name: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/tool/cli.rs
+++ b/src/tool/cli.rs
@@ -15,7 +15,7 @@ use log::{LevelFilter, debug, info};
 #[command(bin_name = "cargo")]
 pub enum TopLevel {
     // This is necessary because it's a cargo subcommand so the first argument needs to be the command name
-    /// A program that given the link or slug to a leetcode problem, creates a local file where you can develop and test your solution before post it back to leetcode.
+    /// A program that given the link or slug to a leetcode problem, creates a local file where you can develop and test your solution before posting it back to leetcode.
     Leet(Cli),
 }
 

--- a/src/tool/cli.rs
+++ b/src/tool/cli.rs
@@ -76,7 +76,7 @@ pub struct GenerateArgs {
     /// Question slug or url (If none specified then daily challenge is used)
     pub problem: Option<String>,
 
-    /// If set the module name generated includes the number for the problem
+    /// If set the module name generated WILL include the number for the problem
     #[arg(
         group = "mod_name",
         short = 'n',
@@ -85,7 +85,7 @@ pub struct GenerateArgs {
     )]
     pub should_include_problem_number_in_mod_name: bool,
 
-    /// If set the module name generated will not include the number for the problem
+    /// If set the module name generated will NOT include the number for the problem
     #[arg(
         group = "mod_name",
         short = 'm',

--- a/src/tool/config_file.rs
+++ b/src/tool/config_file.rs
@@ -5,8 +5,10 @@ use log::info;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
+#[serde(default, deny_unknown_fields)]
 pub(crate) struct ConfigFile {
     pub active: Option<String>,
+    pub should_include_problem_number_in_mod_name: bool,
 }
 
 impl ConfigFile {

--- a/src/tool/core/generate.rs
+++ b/src/tool/core/generate.rs
@@ -19,6 +19,8 @@ pub(crate) const SEPARATOR: &str =
     "// << ---------------- Code below here is only for local use ---------------- >>";
 
 pub(crate) fn do_generate(args: &cli::GenerateArgs) -> anyhow::Result<()> {
+    let mut config = ConfigFile::load().context("failed to load config")?;
+
     let title_slug: Cow<str> = if let Some(specific_problem) = &args.problem {
         get_slug_from_args(specific_problem)
             .with_context(|| format!("expected URL or slug but got {specific_problem}"))?
@@ -38,7 +40,6 @@ pub(crate) fn do_generate(args: &cli::GenerateArgs) -> anyhow::Result<()> {
     write_to_disk::write_file(&module_name, &module_code).context("failed to write to disk")?;
     println!("Generated module: {module_name}");
 
-    let mut config = ConfigFile::load().context("failed to load config")?;
     config.active = Some(module_name);
     config.save().context("failed to save config")?;
 

--- a/src/tool/core/generate.rs
+++ b/src/tool/core/generate.rs
@@ -31,7 +31,23 @@ pub(crate) fn do_generate(args: &cli::GenerateArgs) -> anyhow::Result<()> {
         Cow::Owned(slug)
     };
 
-    let should_include_problem_number_in_mod_name = args.should_include_problem_number_in_mod_name;
+    assert!(
+        !(args.should_include_problem_number_in_mod_name
+            && args.should_not_include_problem_number_in_mod_name),
+        "Both 'should include' and 'should not include' are true. Impossible to satisfy, was intended to be prevented by Clap group"
+    );
+
+    let should_include_problem_number_in_mod_name =
+        if args.should_include_problem_number_in_mod_name {
+            // User wants problem number so this takes precedence
+            true
+        } else if args.should_not_include_problem_number_in_mod_name {
+            // User does not want problem number so this takes precedence
+            false
+        } else {
+            // Use default from loaded preferences
+            config.should_include_problem_number_in_mod_name
+        };
 
     let (module_name, module_code) =
         create_module_code(&title_slug, should_include_problem_number_in_mod_name).with_context(

--- a/src/tool/core/generate.rs
+++ b/src/tool/core/generate.rs
@@ -29,9 +29,12 @@ pub(crate) fn do_generate(args: &cli::GenerateArgs) -> anyhow::Result<()> {
         Cow::Owned(slug)
     };
 
-    let (module_name, module_code) = create_module_code(&title_slug, args).with_context(|| {
-        format!("failed to generate the name and module code for {title_slug:?}")
-    })?;
+    let should_include_problem_number_in_mod_name = args.should_include_problem_number_in_mod_name;
+
+    let (module_name, module_code) =
+        create_module_code(&title_slug, should_include_problem_number_in_mod_name).with_context(
+            || format!("failed to generate the name and module code for {title_slug:?}"),
+        )?;
     write_to_disk::write_file(&module_name, &module_code).context("failed to write to disk")?;
     println!("Generated module: {module_name}");
 
@@ -64,7 +67,7 @@ fn get_slug_from_args(specific_problem: &String) -> anyhow::Result<Cow<'_, str>>
 /// of the input
 fn create_module_code(
     title_slug: &str,
-    args: &cli::GenerateArgs,
+    should_include_problem_number_in_mod_name: bool,
 ) -> anyhow::Result<(String, String)> {
     info!("Building module contents for {title_slug}");
 
@@ -110,7 +113,7 @@ fn create_module_code(
     code_snippet.push_str(&tests);
 
     // Set module name
-    let mut module_name = if args.should_include_problem_number {
+    let mut module_name = if should_include_problem_number_in_mod_name {
         info!("Including problem number in module name");
         format!("_{}_{}", meta_data.id, title_slug.to_case(Case::Snake))
     } else {
@@ -149,7 +152,6 @@ fn url_to_slug(url: &str) -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use cli::GenerateArgs;
     use rstest::rstest;
 
     use crate::tool::core::helpers::local_store::tests::{SlugList, insta_settings, title_slugs};
@@ -181,14 +183,9 @@ mod tests {
 
     #[rstest]
     fn extract_solutions_from_description(title_slugs: SlugList, insta_settings: insta::Settings) {
-        let args = GenerateArgs {
-            problem: None,
-            should_include_problem_number: false,
-        };
-
         for title_slug in title_slugs {
             insta_settings.bind(|| {
-                let (_, code_generated) = create_module_code(title_slug, &args).unwrap();
+                let (_, code_generated) = create_module_code(title_slug, false).unwrap();
                 insta::assert_snapshot!(format!("code_generated {title_slug}"), code_generated);
             });
         }


### PR DESCRIPTION
Based on: #111 

Allows user to save default value for if the problem number default should be true or false.

- Adds a field to the .leet.toml for if the module name should include the problem number. This value serves as the default but can be overridden on the command line.
- Add negative flag for completeness to allow disabling problem numbers in module names
- Moved logic for determining if the problem number should be included in the module name out of the `create_module_code` function so it just takes an argument now. This both simplified the test and made the logic of if the problem number should be included separate.
- Update bacon.toml to make "test" error messages easier

# Updated TODO List from original PR
- [x] Re-introduce --number_in_name, using it to override the config setting
- [x] Introduce negative flag to force no number
- ~~[ ] Add and finalize interactive component.~~ (Will do in separate PR).
- [x] Update readme

NB: I didn't copy over the code for the interactive component. You can add it to this PR or we can do a separate PR after this one lands.

Closes: #107 